### PR TITLE
Allow PRIME offloading with any GPUs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-drivers-common (1:0.8.1pop1) focal; urgency=medium
+
+  [ Tim Crawford ]
+  * gpu-manager.c
+    - Allow offloading on AMD+NVIDIA systems
+
+ -- Tim Crawford <tcrawford@system76.com>  Tue 12 May 2020 12:38:07 PM MDT
+
 ubuntu-drivers-common (1:0.8.1) focal; urgency=medium
 
   [ Alberto Milone ]

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Vcs-Browser: https://github.com/tseliot/ubuntu-drivers-common
 X-Python3-Version: >= 3.2
 
 Package: ubuntu-drivers-common
-Architecture: any
+Architecture: amd64
 Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${python3:Depends},
  ${misc:Depends},
@@ -87,7 +87,7 @@ Description: debhelper extension for scanning kernel module aliases
 Package: nvidia-common
 Section: oldlibs
 Priority: extra
-Architecture: i386 amd64 armel armhf
+Architecture: amd64 armel armhf
 Depends: ubuntu-drivers-common, ${misc:Depends}
 Description: transitional package for ubuntu-drivers-common
  This is a transitional package for ubuntu-drivers-common. You can remove it
@@ -96,7 +96,7 @@ Description: transitional package for ubuntu-drivers-common
 Package: fglrx-pxpress
 Section: oldlibs
 Priority: extra
-Architecture: i386 amd64
+Architecture: amd64
 Depends: ubuntu-drivers-common, ${misc:Depends}
 Description: transitional package for ubuntu-drivers-common
  This is a transitional package for ubuntu-drivers-common. You can remove it


### PR DESCRIPTION
Remove the limitation of PRIME render offloading only being available for systems with an Intel iGPU used as the default display controller.