### PR TITLE
gpu-manager: Don't unload NVIDIA drivers

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1635,8 +1635,8 @@ static bool enable_prime(const char *prime_settings,
                         const struct device *device,
                         struct device **devices,
                         int cards_n) {
-    bool status = false;
-    int tries = 0;
+    //bool status = false;
+    //int tries = 0;
     /* Check if prime_settings is available
      * File doesn't exist or empty
      */
@@ -1680,6 +1680,7 @@ static bool enable_prime(const char *prime_settings,
         remove_prime_outputclass();
         remove_offload_serverlayout();
 
+#if 0
 unload_again:
         /* Unload the NVIDIA modules and enable pci power management */
         if (is_module_loaded("nvidia")) {
@@ -1701,6 +1702,8 @@ unload_again:
                 }
             }
         }
+#endif
+
         /* Set power control to "auto" to save power */
         enable_power_management(device);
     }


### PR DESCRIPTION
In Pop!_OS, the state of the modules is controlled by blacklisting them using system76-power. Stop forcibly unloading them so they are available without user intervention on system start. This allows using the dGPU as a compute node when the NVIDIA mode is set to 'off'.

Ref: pop-os/system76-power#162