### PR TITLE
gpu-manager: HACK: Give GPU enough time to initialize

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2027,6 +2027,10 @@ unload_again:
         }
 #endif
 
+        // XXX: HACK: Give the GPU time to initialize
+        fprintf(log_handle, "Giving GPU time to initialize...\n");
+        sleep(1);
+
         /* Set power control to "auto" to save power */
         enable_power_management(device);
     }


### PR DESCRIPTION
With 450.57 drivers, GPU screens must be disabled so they are not used for rendering displays. Because the device is not used, enabling power management causes it to be suspended before it finishes initializing. Add a sleep to give the drivers enough time to initialize the device.