### PR TITLE
gpu-manager: Wait longer for GPU init

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-drivers-common (1:0.9.2.1pop0) impish; urgency=medium
+
+  * gpu-manager.c
+    - Don't force unloading of NVIDIA drivers
+    - Delay enabling power management so dGPU initializes
+
+ -- Tim Crawford <tcrawford@system76.com>  Fri, 24 Sep 2021 15:46:30 -0600
+
 ubuntu-drivers-common (1:0.9.2.1) impish; urgency=medium
 
   * UbuntuDrivers/detect.py:

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Vcs-Browser: https://github.com/tseliot/ubuntu-drivers-common
 X-Python3-Version: >= 3.2
 
 Package: ubuntu-drivers-common
-Architecture: any
+Architecture: amd64
 Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${python3:Depends},
  ${misc:Depends},
@@ -87,7 +87,7 @@ Description: debhelper extension for scanning kernel module aliases
 Package: nvidia-common
 Section: oldlibs
 Priority: extra
-Architecture: i386 amd64 armel armhf
+Architecture: amd64 armel armhf
 Depends: ubuntu-drivers-common, ${misc:Depends}
 Description: transitional package for ubuntu-drivers-common
  This is a transitional package for ubuntu-drivers-common. You can remove it
@@ -96,7 +96,7 @@ Description: transitional package for ubuntu-drivers-common
 Package: fglrx-pxpress
 Section: oldlibs
 Priority: extra
-Architecture: i386 amd64
+Architecture: amd64
 Depends: ubuntu-drivers-common, ${misc:Depends}
 Description: transitional package for ubuntu-drivers-common
  This is a transitional package for ubuntu-drivers-common. You can remove it

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,15 @@
 from setuptools import setup
 
 import subprocess, glob, os.path
-import os
+import os, sys
 
 extra_data = []
 # Build hybrid-detect on x86
 if '86' in os.uname()[4]:
-    subprocess.check_call(["make", "-C", "share/hybrid", "all"])
+    if 'clean' in sys.argv:
+        subprocess.check_call(["make", "-C", "share/hybrid", "clean"])
+    else:
+        subprocess.check_call(["make", "-C", "share/hybrid", "all"])
     extra_data.append(("/usr/bin/", ["share/hybrid/gpu-manager"]))
     extra_data.append(("/lib/systemd/system/", ["share/hybrid/gpu-manager.service"]))
     extra_data.append(("/sbin/", ["share/hybrid/u-d-c-print-pci-ids"]))

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2112,6 +2112,10 @@ unload_again:
         }
 #endif
 
+        // XXX: HACK: Give the GPU time to initialize
+        fprintf(log_handle, "Giving GPU time to initialize...\n");
+        sleep(1);
+
         /* Set power control to "auto" to save power */
         enable_power_management(device);
     }

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2043,8 +2043,8 @@ static bool enable_prime(const char *prime_settings,
                         const struct device *device,
                         struct device **devices,
                         int cards_n) {
-    bool status = false;
-    int tries = 0;
+    //bool status = false;
+    //int tries = 0;
     /* Check if prime_settings is available
      * File doesn't exist or empty
      */
@@ -2088,6 +2088,7 @@ static bool enable_prime(const char *prime_settings,
         remove_prime_outputclass();
         remove_offload_serverlayout();
 
+#if 0
 unload_again:
         /* Unload the NVIDIA modules and enable pci power management */
         if (is_module_loaded("nvidia")) {
@@ -2109,6 +2110,8 @@ unload_again:
                 }
             }
         }
+#endif
+
         /* Set power control to "auto" to save power */
         enable_power_management(device);
     }

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2079,6 +2079,11 @@ static bool enable_prime(const char *prime_settings,
         create_offload_serverlayout();
         /* Remove the OutputClass */
         remove_prime_outputclass();
+
+        // XXX: HACK: Give the GPU time to initialize
+        fprintf(log_handle, "Giving GPU time to initialize...\n");
+        sleep(5);
+
         enable_power_management(device);
         if (!is_module_loaded("nvidia"))
             load_module("nvidia");
@@ -2114,7 +2119,7 @@ unload_again:
 
         // XXX: HACK: Give the GPU time to initialize
         fprintf(log_handle, "Giving GPU time to initialize...\n");
-        sleep(1);
+        sleep(5);
 
         /* Set power control to "auto" to save power */
         enable_power_management(device);


### PR DESCRIPTION
Increase the wait from 1 second to 5 seconds. Add it for hybrid graphics as well.

Resolves: system76/firmware-open#160
Resolves: system76/firmware-open#259